### PR TITLE
Add Expo React Native app skeleton

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { NavigationContainer } from '@react-navigation/native';
+import RootTabs from './src/navigation';
+import ChatScreen from './src/screens/ChatScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="Root" component={RootTabs as any} />
+        <Stack.Screen name="ChatDetail" component={ChatScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/app.json
+++ b/app.json
@@ -1,0 +1,15 @@
+{
+  "expo": {
+    "name": "TAKTIKKAT",
+    "slug": "taktikkat",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "scheme": "taktikkat",
+    "userInterfaceStyle": "automatic",
+    "splash": { "image": "./assets/splash.png", "resizeMode": "contain", "backgroundColor": "#ffffff" },
+    "ios": { "supportsTablet": true },
+    "android": { "adaptiveIcon": { "foregroundImage": "./assets/adaptive-icon.png", "backgroundColor": "#ffffff" } },
+    "web": { "bundler": "metro", "output": "static", "favicon": "./assets/favicon.png" }
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: []
+  };
+};

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,23 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /posts/{postId} {
+      allow read: if true;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
+      allow update, delete: if request.auth != null && request.auth.uid == resource.data.userId;
+    }
+    match /stories/{storyId} {
+      allow read: if true;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
+      allow delete: if request.auth != null && request.auth.uid == resource.data.userId;
+    }
+    match /threads/{threadId} {
+      allow read: if true;
+      allow create: if request.auth != null;
+      match /messages/{messageId} {
+        allow read: if true;
+        allow create: if request.auth != null;
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "taktikkat",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start -c",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~52.0.0",
+    "expo-image-picker": "~16.0.3",
+    "expo-av": "~14.0.5",
+    "react": "18.2.0",
+    "react-native": "0.74.3",
+    "@react-navigation/native": "^6.1.17",
+    "@react-navigation/native-stack": "^6.9.26",
+    "@react-navigation/bottom-tabs": "^6.5.20",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "~4.9.0",
+    "react-native-gesture-handler": "~2.20.0",
+    "firebase": "^10.12.0",
+    "react-native-svg": "15.2.0",
+    "dayjs": "^1.11.11"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/react": "~18.2.79",
+    "@types/react-native": "~0.73.0"
+  }
+}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Svg, { Circle, Polygon, Path, Text as SvgText } from 'react-native-svg';
+import { View } from 'react-native';
+
+export default function Logo({ size = 64 }: { size?: number }) {
+  const w = size;
+  const h = size;
+  return (
+    <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+      <Svg width={w} height={h} viewBox="0 0 100 100">
+        {/* Cat head */}
+        <Circle cx="50" cy="48" r="22" fill="#000" />
+        {/* Ears */}
+        <Polygon points="35,28 45,20 45,36" fill="#000" />
+        <Polygon points="65,28 55,20 55,36" fill="#000" />
+        {/* Eyes */}
+        <Circle cx="43" cy="48" r="3" fill="#fff" />
+        <Circle cx="57" cy="48" r="3" fill="#fff" />
+        {/* Nose */}
+        <Circle cx="50" cy="54" r="2" fill="#fff" />
+        {/* Tail (abstract arc) */}
+        <Path d="M78 60 C90 48, 90 80, 78 70" strokeWidth="6" stroke="#000" fill="none" />
+      </Svg>
+      <Svg width={w} height={24} viewBox="0 0 100 24">
+        <SvgText x="50" y="18" fontSize="18" fontWeight="bold" textAnchor="middle">TAKTIKKAT</SvgText>
+      </Svg>
+    </View>
+  );
+}

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+import { Video } from 'expo-av';
+
+export type Post = {
+  id: string;
+  userId: string;
+  username: string;
+  caption?: string;
+  mediaUrl: string;
+  mediaType: 'image' | 'video';
+  createdAt: number;
+};
+
+export default function PostCard({ post }: { post: Post }) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.user}>@{post.username}</Text>
+      {post.mediaType === 'image' ? (
+        <Image source={{ uri: post.mediaUrl }} style={styles.media} resizeMode="cover" />
+      ) : (
+        <Video
+          source={{ uri: post.mediaUrl }}
+          style={styles.media}
+          useNativeControls
+          resizeMode="cover"
+          isLooping
+        />
+      )}
+      {post.caption ? <Text style={styles.caption}>{post.caption}</Text> : null}
+      <Text style={styles.time}>{new Date(post.createdAt).toLocaleString()}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { backgroundColor: '#fff', marginBottom: 12, borderRadius: 12, overflow: 'hidden' },
+  user: { padding: 12, fontWeight: '600' },
+  media: { width: '100%', height: 300, backgroundColor: '#eee' },
+  caption: { padding: 12 },
+  time: { paddingHorizontal: 12, paddingBottom: 12, color: '#777' }
+});

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,10 @@
+import { initializeApp, getApps } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
+import { firebaseConfig } from './firebaseConfig';
+
+const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const storage = getStorage(app);

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -1,0 +1,8 @@
+export const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import FeedScreen from '../screens/FeedScreen';
+import CreatePostScreen from '../screens/CreatePostScreen';
+import StoryScreen from '../screens/StoryScreen';
+import ChatListScreen from '../screens/ChatListScreen';
+import ProfileScreen from '../screens/ProfileScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function RootTabs() {
+  return (
+    <Tab.Navigator screenOptions={{ headerShown: false }}>
+      <Tab.Screen name="Feed" component={FeedScreen} />
+      <Tab.Screen name="Create" component={CreatePostScreen} />
+      <Tab.Screen name="Stories" component={StoryScreen} />
+      <Tab.Screen name="Chat" component={ChatListScreen} />
+      <Tab.Screen name="Profile" component={ProfileScreen} />
+    </Tab.Navigator>
+  );
+}

--- a/src/screens/ChatListScreen.tsx
+++ b/src/screens/ChatListScreen.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, TouchableOpacity, SafeAreaView } from 'react-native';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+
+type Thread = { id: string; title: string };
+
+export default function ChatListScreen({ navigation }: any) {
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const load = async () => {
+    const snap = await getDocs(collection(db, 'threads'));
+    setThreads(snap.docs.map(d => ({ id: d.id, ...(d.data() as any) })));
+  };
+  useEffect(() => { load(); }, []);
+
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <FlatList
+        data={threads}
+        keyExtractor={(i) => i.id}
+        renderItem={({ item }) => (
+          <TouchableOpacity onPress={() => navigation.navigate('ChatDetail', { threadId: item.id, title: item.title })}>
+            <View style={{ padding: 16, borderBottomWidth: 1, borderBottomColor: '#eee' }}>
+              <Text style={{ fontWeight: '600' }}>{item.title}</Text>
+              <Text style={{ color: '#777' }}>Öffnen…</Text>
+            </View>
+          </TouchableOpacity>
+        )}
+      />
+    </SafeAreaView>
+  );
+}

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button, FlatList, SafeAreaView } from 'react-native';
+import { db } from '../firebase';
+import { addDoc, collection, onSnapshot, orderBy, query, serverTimestamp } from 'firebase/firestore';
+
+type Message = { id: string; text: string; userId: string; createdAt: any };
+
+export default function ChatScreen({ route }: any) {
+  const { threadId } = route.params;
+  const [text, setText] = useState('');
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  useEffect(() => {
+    const q = query(collection(db, 'threads', threadId, 'messages'), orderBy('createdAt', 'desc'));
+    const unsub = onSnapshot(q, snap => {
+      setMessages(snap.docs.map(d => ({ id: d.id, ...(d.data() as any) })));
+    });
+    return () => unsub();
+  }, [threadId]);
+
+  const send = async () => {
+    if (!text.trim()) return;
+    await addDoc(collection(db, 'threads', threadId, 'messages'), {
+      text, userId: 'demo', createdAt: serverTimestamp()
+    });
+    setText('');
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1, padding: 12 }}>
+      <FlatList
+        data={messages}
+        keyExtractor={(i) => i.id}
+        inverted
+        renderItem={({ item }) => (
+          <View style={{ padding: 8, alignSelf: item.userId === 'demo' ? 'flex-end' : 'flex-start', backgroundColor: '#e8e8ff', borderRadius: 12, marginVertical: 4 }}>
+            <Text>{item.text}</Text>
+          </View>
+        )}
+      />
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <TextInput value={text} onChangeText={setText} placeholder="Nachricht…" style={{ flex: 1, borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 12 }} />
+        <Button title="Senden" onPress={send} />
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/src/screens/CreatePostScreen.tsx
+++ b/src/screens/CreatePostScreen.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, Image, Alert, SafeAreaView } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { db, storage } from '../firebase';
+import { addDoc, collection } from 'firebase/firestore';
+
+export default function CreatePostScreen() {
+  const [uri, setUri] = useState<string | null>(null);
+  const [type, setType] = useState<'image' | 'video' | null>(null);
+  const [caption, setCaption] = useState('');
+
+  const pick = async (mediaTypes: ImagePicker.MediaTypeOptions) => {
+    const res = await ImagePicker.launchImageLibraryAsync({ mediaTypes, quality: 0.8 });
+    if (!res.canceled) {
+      const asset = res.assets[0];
+      setUri(asset.uri);
+      setType(asset.type === 'video' ? 'video' : 'image');
+    }
+  };
+
+  const publish = async () => {
+    try {
+      if (!uri || !type) return;
+      const blob = await (await fetch(uri)).blob();
+      const id = Date.now().toString();
+      const storageRef = ref(storage, `posts/${id}`);
+      await uploadBytes(storageRef, blob);
+      const url = await getDownloadURL(storageRef);
+      await addDoc(collection(db, 'posts'), {
+        userId: 'demo', username: 'demo',
+        caption, mediaUrl: url, mediaType: type, createdAt: Date.now()
+      });
+      Alert.alert('Erfolg', 'Post veröffentlicht!');
+      setUri(null); setType(null); setCaption('');
+    } catch (e: any) {
+      Alert.alert('Fehler', e.message);
+    }
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Image source={uri ? { uri } : undefined} style={{ width: '100%', height: 280, backgroundColor: '#eee' }} />
+      <View style={{ flexDirection: 'row', gap: 12, justifyContent: 'space-between' }}>
+        <Button title="Foto wählen" onPress={() => pick(ImagePicker.MediaTypeOptions.Images)} />
+        <Button title="Video wählen" onPress={() => pick(ImagePicker.MediaTypeOptions.Videos)} />
+      </View>
+      <TextInput
+        placeholder="Bildunterschrift…"
+        value={caption}
+        onChangeText={setCaption}
+        style={{ borderWidth: 1, borderColor: '#ddd', padding: 12, borderRadius: 8 }}
+      />
+      <Button title="Veröffentlichen" onPress={publish} />
+    </SafeAreaView>
+  );
+}

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { FlatList, SafeAreaView, RefreshControl } from 'react-native';
+import PostCard, { Post } from '../components/PostCard';
+import { collection, getDocs, orderBy, query } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function FeedScreen() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    const q = query(collection(db, 'posts'), orderBy('createdAt', 'desc'));
+    const snap = await getDocs(q);
+    const data: Post[] = snap.docs.map(d => ({ id: d.id, ...d.data() } as any));
+    setPosts(data);
+    setLoading(false);
+  };
+
+  useEffect(() => { load(); }, []);
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#f7f7f7' }}>
+      <FlatList
+        data={posts}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <PostCard post={item} />}
+        contentContainerStyle={{ padding: 12 }}
+        refreshControl={<RefreshControl refreshing={loading} onRefresh={load} />}
+      />
+    </SafeAreaView>
+  );
+}

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View, Text, SafeAreaView } from 'react-native';
+import Logo from '../components/Logo';
+
+export default function ProfileScreen() {
+  return (
+    <SafeAreaView style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+      <Logo size={96} />
+      <Text style={{ fontSize: 24, fontWeight: '700' }}>TAKTIKKAT</Text>
+      <Text>Dein Profil – (Demo)</Text>
+    </SafeAreaView>
+  );
+}

--- a/src/screens/StoryScreen.tsx
+++ b/src/screens/StoryScreen.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { View, FlatList, Image, SafeAreaView, Text, Button, Alert } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import dayjs from 'dayjs';
+import { db, storage } from '../firebase';
+import { collection, query, where, getDocs, addDoc } from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+
+type Story = {
+  id: string;
+  userId: string;
+  mediaUrl: string;
+  createdAt: number;
+  expiresAt: number;
+};
+
+export default function StoryScreen() {
+  const [stories, setStories] = useState<Story[]>([]);
+
+  const load = async () => {
+    const now = Date.now();
+    const q = query(collection(db, 'stories'), where('expiresAt', '>', now));
+    const snap = await getDocs(q);
+    const data: Story[] = snap.docs.map(d => ({ id: d.id, ...d.data() } as any));
+    setStories(data);
+  };
+
+  const addStory = async () => {
+    const res = await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.8 });
+    if (res.canceled) return;
+    try {
+      const asset = res.assets[0];
+      const blob = await (await fetch(asset.uri)).blob();
+      const id = Date.now().toString();
+      const storageRef = ref(storage, `stories/${id}`);
+      await uploadBytes(storageRef, blob);
+      const url = await getDownloadURL(storageRef);
+      const createdAt = Date.now();
+      const expiresAt = dayjs(createdAt).add(24, 'hour').valueOf();
+      await addDoc(collection(db, 'stories'), { userId: 'demo', mediaUrl: url, createdAt, expiresAt });
+      Alert.alert('Story gepostet!');
+      load();
+    } catch (e: any) {
+      Alert.alert('Fehler', e.message);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  return (
+    <SafeAreaView style={{ flex: 1, padding: 12 }}>
+      <Button title="Story hinzufügen" onPress={addStory} />
+      <FlatList
+        data={stories}
+        keyExtractor={(i) => i.id}
+        renderItem={({ item }) => (
+          <View style={{ marginVertical: 8 }}>
+            <Image source={{ uri: item.mediaUrl }} style={{ width: '100%', height: 240, backgroundColor: '#eee' }} />
+            <Text>Verfällt: {new Date(item.expiresAt).toLocaleString()}</Text>
+          </View>
+        )}
+      />
+    </SafeAreaView>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react",
+    "strict": true,
+    "moduleResolution": "Node",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["react", "react-native"]
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Expo-based React Native app with tab navigation and chat screen
- integrate Firebase configuration and Firestore security rules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7a553810c8320a6e60a3d0e82903c