### PR TITLE
Ensure JSON error response in local API

### DIFF
--- a/local_mode/main.py
+++ b/local_mode/main.py
@@ -42,7 +42,11 @@ async def chat(request: ChatCompletionRequest):
         else:
             return JSONResponse(chat_with_codegeex(request))
     except Exception as e:
-        return JSONResponse(e, status_code=500)
+        # JSONResponse expects a serializable content. Returning the exception
+        # object directly results in a "TypeError: Object of type ... is not JSON serializable".
+        # Convert the exception to a string so clients receive a meaningful
+        # error message instead of a server-side serialization failure.
+        return JSONResponse({"error": str(e)}, status_code=500)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- return serialization-safe error message from local API by converting Exception to string
- document reason for change in comments

## Testing
- `python -m py_compile local_mode/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7a54a0b688320b5fffb363be7caf6